### PR TITLE
Add built-in support for `datetime.date`

### DIFF
--- a/plotille/_input_formatter.py
+++ b/plotille/_input_formatter.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 # THE SOFTWARE.
 
 from collections import OrderedDict
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, time, timedelta
 import math
 
 import six
@@ -91,7 +91,7 @@ def _date_formatter(val, chars, delta, left=False):
     assert isinstance(val, date)
     assert isinstance(delta, timedelta)
 
-    val_dt = datetime.combine(val, datetime.min.time())
+    val_dt = datetime.combine(val, time.min)
     return _datetime_formatter(val_dt, chars, delta, left)
 
 
@@ -206,7 +206,7 @@ def _convert_np_datetime(v):
 
 def _convert_date(v):
     assert isinstance(v, date)
-    return (v - date(1970, 1, 1)).days
+    return (v - date.min).days
 
 
 def _convert_datetime(v):

--- a/plotille/_input_formatter.py
+++ b/plotille/_input_formatter.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 # THE SOFTWARE.
 
 from collections import OrderedDict
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 import math
 
 import six
@@ -40,6 +40,7 @@ class InputFormatter(object):
         for int_type in six.integer_types:
             self.formatters[int_type] = _num_formatter
 
+        self.formatters[date] = _date_formatter
         self.formatters[datetime] = _datetime_formatter
 
         self.converters = OrderedDict()
@@ -47,6 +48,7 @@ class InputFormatter(object):
         for int_type in six.integer_types:
             self.converters[int_type] = _convert_numbers
 
+        self.converters[date] = _convert_date
         self.converters[datetime] = _convert_datetime
 
         try:
@@ -83,6 +85,14 @@ def _np_datetime_formatter(val, chars, delta, left=False):
     # assert isinstance(delta, np.timedelta64)
 
     return _datetime_formatter(val.item(), chars, delta.item(), left)
+
+
+def _date_formatter(val, chars, delta, left=False):
+    assert isinstance(val, date)
+    assert isinstance(delta, timedelta)
+
+    val_dt = datetime.combine(val, datetime.min.time())
+    return _datetime_formatter(val_dt, chars, delta, left)
 
 
 def _datetime_formatter(val, chars, delta, left=False):
@@ -192,6 +202,11 @@ def _convert_numbers(v):
 def _convert_np_datetime(v):
     # assert isinstance(v, np.datetime64)
     return timestamp(v.item())
+
+
+def _convert_date(v):
+    assert isinstance(v, date)
+    return (v - date(1970, 1, 1)).days
 
 
 def _convert_datetime(v):

--- a/tests/test_date_formatter.py
+++ b/tests/test_date_formatter.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from datetime import date, timedelta
+import pytest
+
+from plotille._input_formatter import _convert_date, _date_formatter
+
+
+@pytest.fixture()
+def date_a():
+    return date(2019, 1, 2)
+
+
+@pytest.fixture()
+def day():
+    return timedelta(days=1)
+
+
+def test_days(date_a, day):
+    assert ' 19-01-02' == _date_formatter(date_a, chars=9, delta=day*15)
+    assert '19-01-02 ' == _date_formatter(date_a, chars=9, delta=day*15, left=True)
+
+    assert '  2019-01-02' == _date_formatter(date_a, chars=12, delta=day*15)
+    assert '2019-01-02  ' == _date_formatter(date_a, chars=12, delta=day*15, left=True)
+
+    with pytest.raises(ValueError):
+        _date_formatter(date_a, chars=7, delta=day*15)
+
+
+def test_converter(date_a):
+    assert (date_a - date(1970, 1, 1)).days == _convert_date(date_a)

--- a/tests/test_date_formatter.py
+++ b/tests/test_date_formatter.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from datetime import date, timedelta
+
 import pytest
 
 from plotille._input_formatter import _convert_date, _date_formatter
@@ -40,4 +41,4 @@ def test_day_times(date_a, day):
 
 
 def test_converter(date_a):
-    assert (date_a - date(1970, 1, 1)).days == _convert_date(date_a)
+    assert (date_a - date.min).days == _convert_date(date_a)

--- a/tests/test_date_formatter.py
+++ b/tests/test_date_formatter.py
@@ -28,5 +28,16 @@ def test_days(date_a, day):
         _date_formatter(date_a, chars=7, delta=day*15)
 
 
+def test_day_times(date_a, day):
+    assert ' 02T00:00' == _date_formatter(date_a, chars=9, delta=day*5)
+    assert '02T00:00 ' == _date_formatter(date_a, chars=9, delta=day*5, left=True)
+
+    assert ' 02T00:00:00' == _date_formatter(date_a, chars=12, delta=day*5)
+    assert '02T00:00:00 ' == _date_formatter(date_a, chars=12, delta=day*5, left=True)
+
+    with pytest.raises(ValueError):
+        _date_formatter(date_a, chars=7, delta=day*5)
+
+
 def test_converter(date_a):
     assert (date_a - date(1970, 1, 1)).days == _convert_date(date_a)


### PR DESCRIPTION
In a manner similar to how `datetime.datetime` can be passed in, this PR adds support for `datetime.date` objects.

This implementation add a formatter for dates which is effectively a wrapper around the existing datetime formatter, with the constraint that the time portion is always `00:00`.