### PR TITLE
Flit-core backend for pure python builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ keywords = [
 ]
 classifiers = [
   "Environment :: Console",
-  "License :: OSI Approved :: MIT License",
   "Intended Audience :: Science/Research",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
@@ -139,8 +138,8 @@ disallow_any_unimported = true
 # warn_unreachable = false
 
 [build-system]
-requires = ["uv_build>=0.7.19,<0.8.0"]
-build-backend = "uv_build"
+requires = ["flit_core >=3.2,<4"]
+build-backend = "flit_core.buildapi"
 
 [tool.uv.build-backend]
 module-name = "plotille"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plotille"
-version = "6.0.4"
+version = "6.0.5"
 description = "Plot in the terminal using braille dots."
 authors = [{ name = "Tammo Ippen", email = "tammo.ippen@posteo.de" }]
 requires-python = ">=3.10,<4"

--- a/uv.lock
+++ b/uv.lock
@@ -533,7 +533,7 @@ wheels = [
 
 [[package]]
 name = "plotille"
-version = "6.0.4"
+version = "6.0.5"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
fixes #70 

This pull request updates the packaging and build configuration for the `plotille` project, primarily switching the build backend from `uv_build` to `flit_core` and incrementing the project version. These changes help modernize the build process and prepare for future releases.

**Packaging and build system updates:**

* Updated project version from `6.0.4` to `6.0.5` in `pyproject.toml` to reflect new changes.
* Changed the build backend from `uv_build` to `flit_core` and updated the `requires` field to use `flit_core` instead of `uv_build` in `pyproject.toml`.

**Other configuration changes:**

* Removed the `License :: OSI Approved :: MIT License` classifier from the `classifiers` list in `pyproject.toml` - requirement from flit-core.